### PR TITLE
Application completion

### DIFF
--- a/app/controllers/admin_applications_controller.rb
+++ b/app/controllers/admin_applications_controller.rb
@@ -1,5 +1,6 @@
 class AdminApplicationsController < ApplicationController
   def show
     @application = Application.find(params[:application_id])
+    @application.approved?
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,15 +5,18 @@ class Application < ApplicationRecord
   validates :zip_code, length: { is: 5 }
   validates :zip_code, :numericality => { :greater_than_or_equal_to => 0}
 
-  def approved?
-    application_pets = pets.map do |pet|
+  def application_pets
+    pets.map do |pet|
       ApplicationPet.find_application_pet(id, pet.id)
     end
+  end
 
+  def approved?
     if application_pets.all? { |application_pet| application_pet.pet_status == 'Approved' }
       update(status: "Approved")
       save
-      pets.each { |pet| pet.update(adoptable: false) pet.save }
+      pets.each { |pet| pet.update(adoptable: false)
+        pet.save }
     elsif application_pets.any? { |application_pet| application_pet.pet_status == 'Rejected' }
       update(status: "Rejected")
       save

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -4,4 +4,19 @@ class Application < ApplicationRecord
   validates :name, :street_address, :city, :state, :zip_code, presence: true
   validates :zip_code, length: { is: 5 }
   validates :zip_code, :numericality => { :greater_than_or_equal_to => 0}
+
+  def approved?
+    application_pets = pets.map do |pet|
+      ApplicationPet.find_application_pet(id, pet.id)
+    end
+
+    if application_pets.all? { |application_pet| application_pet.pet_status == 'Approved' }
+      update(status: "Approved")
+      save
+      pets.each { |pet| pet.update(adoptable: false) pet.save }
+    elsif application_pets.any? { |application_pet| application_pet.pet_status == 'Rejected' }
+      update(status: "Rejected")
+      save
+    end
+  end
 end

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -7,7 +7,11 @@ Pets inquired about:
 <% @application.pets.each do |pet| %>
   <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
   <% if pet.application_status(@application.id) == 'Pending' %>
-    <%= button_to "Approve #{pet.name}", "/admin/applications/#{@application.id}/#{pet.id}/Approved", method: :patch %>
+    <% if pet.adoptable %>
+      <%= button_to "Approve #{pet.name}", "/admin/applications/#{@application.id}/#{pet.id}/Approved", method: :patch %>
+    <% else %>
+      <%= 'Dogmin has been approved on a different application' %>
+    <% end %>
     <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}/#{pet.id}/Rejected", method: :patch %>
   <% else %>
     <%= "#{pet.application_status(@application.id)}" %>

--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Application show view' do
     expect(page).to have_button("Approve Dogmin")
   end
 
-  it 'approval or rejection on one application does not affect another' do
+  it 'approves the application if all pets are approved' do
     @pet_1 = @application.pets.create(adoptable: true, age: 1, breed: 'sphynx', name: 'Lucille Bald', shelter_id: @shelter.id)
     @pet_2 = @application.pets.create(adoptable: true, age: 5, breed: 'lab', name: 'Dogmin', shelter_id: @shelter.id)
     @application_2 = Application.create!({
@@ -105,5 +105,29 @@ RSpec.describe 'Application show view' do
 
     expect(page).to have_content('Status: Approved')
     expect(page).to_not have_content('Status: In Progress')
+  end
+
+  it 'rejects the application if any pets are rejected' do
+    @pet_1 = @application.pets.create(adoptable: true, age: 1, breed: 'sphynx', name: 'Lucille Bald', shelter_id: @shelter.id)
+    @pet_2 = @application.pets.create(adoptable: true, age: 5, breed: 'lab', name: 'Dogmin', shelter_id: @shelter.id)
+    @application_2 = Application.create!({
+      name: "Sam",
+      street_address: "31779 Quarterhorse Rd",
+      city: "Evergreen",
+      state: "CO",
+      zip_code: 80439,
+      reason: "Because!"
+      })
+
+    ApplicationPet.create!(pet_id: @pet_2.id, application_id: @application_2.id)
+
+    visit "/admin/applications/#{@application.id}"
+
+    click_button "Reject Dogmin"
+    click_button "Approve Lucille Bald"
+
+    expect(page).to have_content('Status: Rejected')
+    expect(page).to_not have_content('Status: In Progress')
+    expect(page).to_not have_content('Status: Approved')
   end
 end

--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -79,9 +79,31 @@ RSpec.describe 'Application show view' do
 
     visit "/admin/applications/#{@application_2.id}"
 
-
     expect(page).to_not have_content("Rejected")
     expect(page).to have_button("Reject Dogmin")
     expect(page).to have_button("Approve Dogmin")
+  end
+
+  it 'approval or rejection on one application does not affect another' do
+    @pet_1 = @application.pets.create(adoptable: true, age: 1, breed: 'sphynx', name: 'Lucille Bald', shelter_id: @shelter.id)
+    @pet_2 = @application.pets.create(adoptable: true, age: 5, breed: 'lab', name: 'Dogmin', shelter_id: @shelter.id)
+    @application_2 = Application.create!({
+      name: "Sam",
+      street_address: "31779 Quarterhorse Rd",
+      city: "Evergreen",
+      state: "CO",
+      zip_code: 80439,
+      reason: "Because!"
+      })
+
+    ApplicationPet.create!(pet_id: @pet_2.id, application_id: @application_2.id)
+
+    visit "/admin/applications/#{@application.id}"
+
+    click_button "Approve Dogmin"
+    click_button "Approve Lucille Bald"
+
+    expect(page).to have_content('Status: Approved')
+    expect(page).to_not have_content('Status: In Progress')
   end
 end

--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -160,4 +160,29 @@ RSpec.describe 'Application show view' do
     expect(page).to have_content(false)
     expect(page).to_not have_content(true)
   end
+
+  it 'approves the application if all pets are approved' do
+    @pet_1 = @application.pets.create(adoptable: true, age: 1, breed: 'sphynx', name: 'Lucille Bald', shelter_id: @shelter.id)
+    @pet_2 = @application.pets.create(adoptable: true, age: 5, breed: 'lab', name: 'Dogmin', shelter_id: @shelter.id)
+    @application_2 = Application.create!({
+      name: "Sam",
+      street_address: "31779 Quarterhorse Rd",
+      city: "Evergreen",
+      state: "CO",
+      zip_code: 80439,
+      reason: "Because!"
+      })
+
+    ApplicationPet.create!(pet_id: @pet_2.id, application_id: @application_2.id)
+
+    visit "/admin/applications/#{@application.id}"
+
+    click_button "Approve Dogmin"
+    click_button "Approve Lucille Bald"
+
+    visit "/admin/applications/#{@application_2.id}"
+
+    expect(page).to have_content("Dogmin has been approved on a different application")
+    expect(page).to_not have_button("Approve Dogmin")
+  end
 end

--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -130,4 +130,34 @@ RSpec.describe 'Application show view' do
     expect(page).to_not have_content('Status: In Progress')
     expect(page).to_not have_content('Status: Approved')
   end
+
+  it 'approves the application if all pets are approved' do
+    @pet_1 = @application.pets.create(adoptable: true, age: 1, breed: 'sphynx', name: 'Lucille Bald', shelter_id: @shelter.id)
+    @pet_2 = @application.pets.create(adoptable: true, age: 5, breed: 'lab', name: 'Dogmin', shelter_id: @shelter.id)
+    @application_2 = Application.create!({
+      name: "Sam",
+      street_address: "31779 Quarterhorse Rd",
+      city: "Evergreen",
+      state: "CO",
+      zip_code: 80439,
+      reason: "Because!"
+      })
+
+    ApplicationPet.create!(pet_id: @pet_2.id, application_id: @application_2.id)
+
+    visit "/admin/applications/#{@application.id}"
+
+    click_button "Approve Dogmin"
+    click_button "Approve Lucille Bald"
+
+    visit "/pets/#{@pet_1.id}"
+
+    expect(page).to have_content(false)
+    expect(page).to_not have_content(true)
+
+    visit "/pets/#{@pet_2.id}"
+
+    expect(page).to have_content(false)
+    expect(page).to_not have_content(true)
+  end
 end


### PR DESCRIPTION
This PR adds functionality to fully approve or reject an application depending on interaction with the pets on that application. It also makes sure that pets cannot be approved if they are already part of an approved application. It also makes sure that a pet is not adoptable if they are part of an approved application